### PR TITLE
Updating pkt test to base standard

### DIFF
--- a/test/testcne/pkt_test.c
+++ b/test/testcne/pkt_test.c
@@ -60,42 +60,39 @@ simple_pkt_test(void)
     int ret              = -1;
     pktmbuf_t *mbufs[32] = {NULL};
 
-    cne_printf("[blue]>>>[white]SUBTEST: pktmbuf_pool_create\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_pool_create");
 
     if (create_pktmbuf())
         goto leave;
-    tst_ok("PASS --- SUBTEST: pktmbuf_pool_create\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_pool_create");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc_bulk\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc_bulk");
     ret = pktmbuf_alloc_bulk(pi, mbufs, 32);
     TST_ASSERT_GOTO(ret > 0, "SUBTEST: pktmbuf_alloc_bulk failed\n", leave);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc_bulk\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc_bulk");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_copy\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_copy");
     uint64_t *p                = pktmbuf_mtod(mbufs[0], uint64_t *);
     p[0]                       = 0xfd3c78299efefd3c;
     p[1]                       = 0x00450008b82c9efe;
     p[2]                       = 0x0;
     pktmbuf_data_len(mbufs[0]) = 60;
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("pktmbuf[0]", mbufs[0], pktmbuf_data_len(mbufs[0]));
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     pktmbuf_t *copy = pktmbuf_copy(mbufs[0], pi, 0, UINT32_MAX);
     TST_ASSERT_GOTO(copy, "SUBTEST: pktmbuf_copy failed\n", leave);
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("copy", copy, pktmbuf_data_len(copy));
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
-    tst_ok("PASS --- SUBTEST: pktmbuf_copy\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_copy");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: memcmp copied buffer\n");
+    tst_info("SUBTEST: memcmp copied buffer");
     uint64_t *p1 = pktmbuf_mtod(copy, uint64_t *);
     ret          = memcmp(p, p1, 60);
     TST_ASSERT_GOTO(ret == 0, "SUBTEST: memcmp copied buffer failed\n", leave);
-    tst_ok("PASS --- SUBTEST:  memcmp copied buffer\n");
+    tst_ok("PASS --- SUBTEST:  memcmp copied buffer");
     pktmbuf_free(copy);
 
 leave:
@@ -114,157 +111,137 @@ test_one_pktmbuf(void)
     char *data, *data2, *hdr;
     unsigned i;
 
-    cne_printf("[blue]>>>[white]SUBTEST: pktmbuf API\n");
+    tst_info("SUBTEST: pktmbuf API");
 
     /* alloc a pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     m = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(m, "SUBTEST: pktmbuf_alloc failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_data_len\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_data_len");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == 0, "SUBTEST: pktmbuf_data_len failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_data_len\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_data_len");
 
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, 0);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     /* append data */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append");
     data = pktmbuf_append(m, MBUF_TEST_DATA_LEN);
     TST_ASSERT_GOTO(data != NULL, "SUBTEST: pktmbuf_append failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_data_len\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_data_len");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: pktmbuf_data_len failed\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_data_len\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_data_len");
 
     memset(data, 0x66, pktmbuf_data_len(m));
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, MBUF_TEST_DATA_LEN);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
-    cne_printf("\n[blue]>>>[white]pktmbuf_data_len(m) %d\n", pktmbuf_data_len(m));
+    tst_info("pktmbuf_data_len(m) %d", pktmbuf_data_len(m));
 
     /* this append should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append invalid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append invalid");
     data2 = pktmbuf_append(m, (uint16_t)(pktmbuf_tailroom(m) + 1));
     TST_ASSERT_GOTO(data2 == NULL, "SUBTEST: pktmbuf_append invalid failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append invalid\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append invalid");
 
     /* append some more data */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append valid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append valid");
     data2 = pktmbuf_append(m, MBUF_TEST_DATA_LEN2);
     TST_ASSERT_GOTO(data2 != NULL, "SUBTEST: pktmbuf_append valid failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append valid\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append valid");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Check packet length valid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Check packet length valid");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == (MBUF_TEST_DATA_LEN + MBUF_TEST_DATA_LEN2),
                     "SUBTEST: Check packet length valid\n", fail);
-    tst_ok("PASS --- SUBTEST: Check packet length valid\n");
+    tst_ok("PASS --- SUBTEST: Check packet length valid");
 
     /* trim data at the end of pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_trim(m, MBUF_TEST_DATA_LEN2) == 0, "SUBTEST: pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_trim");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: check length after pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: check length after pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN,
                     "SUBTEST: check length after pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: check length after pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: check length after pktmbuf_trim");
 
     /* this trim should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: invalid pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: invalid pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_trim(m, (uint16_t)(pktmbuf_data_len(m) + 1)) != 0,
                     "SUBTEST: invalid pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: invalid pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: invalid pktmbuf_trim");
 
     /* prepend one header */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend one header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend one header");
     hdr = pktmbuf_prepend(m, MBUF_TEST_HDR1_LEN);
     TST_ASSERT_GOTO(hdr != NULL, "SUBTEST: prepend one header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend one header\n");
+    tst_ok("PASS --- SUBTEST: prepend one header");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 1\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 1");
     TST_ASSERT_GOTO(data - hdr == MBUF_TEST_HDR1_LEN, "SUBTEST: Verify prepend one header 1\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 1\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 1");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 2\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 2");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN + MBUF_TEST_HDR1_LEN,
                     "SUBTEST: Verify prepend one header 2\n", fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 2\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 2");
 
     memset(hdr, 0x55, MBUF_TEST_HDR1_LEN);
 
     /* prepend another header */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend another valid header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend another valid header");
     hdr = pktmbuf_prepend(m, MBUF_TEST_HDR2_LEN);
     TST_ASSERT_GOTO(hdr != NULL, "SUBTEST: prepend another valid header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend another valid header\n");
+    tst_ok("PASS --- SUBTEST: prepend another valid header");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 1\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 1");
     TST_ASSERT_GOTO(data - hdr == MBUF_TEST_ALL_HDRS_LEN, "SUBTEST: Verify prepend one header 1\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 1\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 1");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 2\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 2");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN + MBUF_TEST_ALL_HDRS_LEN,
                     "SUBTEST: Verify prepend one header 2\n", fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 2\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 2");
 
     memset(hdr, 0x55, MBUF_TEST_HDR2_LEN);
 
     pktmbuf_sanity_check(m, 1);
     pktmbuf_sanity_check(m, 0);
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, 0);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     /* this prepend should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend an invalid header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend an invalid header");
     hdr = pktmbuf_prepend(m, (uint16_t)(CNE_PKTMBUF_HEADROOM + 1));
     TST_ASSERT_GOTO(hdr == NULL, "SUBTEST: prepend an invalid header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend an invalid header\n");
+    tst_ok("PASS --- SUBTEST: prepend an invalid header");
 
     /* remove data at beginning of pktmbuf (adj) */
-    cne_printf("\n[blue]>>>[white]SUBTEST: remove data at beginning of pktmbuf (adj)\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: remove data at beginning of of pktmbuf (adj)");
     TST_ASSERT_GOTO(data == pktmbuf_adj_offset(m, MBUF_TEST_ALL_HDRS_LEN),
                     "SUBTEST: remove data at beginning of pktmbuf (adj)\n", fail);
-    tst_ok("PASS --- SUBTEST: remove data at beginning of pktmbuf (adj)\n");
+    tst_ok("PASS --- SUBTEST: remove data at beginning of pktmbuf (adj)");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify pktmbuf_prepend\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify pktmbuf_prepend");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: Verify pktmbuf_prepend\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify pktmbuf_prepend\n");
+    tst_ok("PASS --- SUBTEST: Verify pktmbuf_prepend");
 
     /* this adj should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: invalid remove data at beginning of pktmbuf (adj)\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: invalid remove data at beginning of pktmbuf (adj)");
     TST_ASSERT_GOTO(pktmbuf_adj_offset(m, (uint16_t)(pktmbuf_data_len(m) + 1)) == NULL,
                     "SUBTEST: invalid  remove data at beginning of pktmbuf (adj)\n", fail);
-    tst_ok("PASS --- SUBTEST:  invalid remove data at beginning of pktmbuf (adj)\n");
+    tst_ok("PASS --- SUBTEST:  invalid remove data at beginning of pktmbuf (adj)");
 
     for (i = 0; i < MBUF_TEST_DATA_LEN; i++) {
         if (data[i] != 0x66) {
@@ -272,14 +249,14 @@ test_one_pktmbuf(void)
             goto fail;
         }
     }
-    tst_ok("PASS --- SUBTEST: pktmbuf API\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf API");
     /* free pktmbuf */
     pktmbuf_free(m);
     m = NULL;
     return 0;
 
 fail:
-    tst_error("FAILED --- SUBTEST: pktmbuf API\n");
+    tst_error("FAILED --- SUBTEST: pktmbuf API");
     pktmbuf_free(m);
     return -1;
 }
@@ -293,26 +270,25 @@ test_pktmbuf_pool(void)
     unsigned i;
     pktmbuf_t *m[DEFAULT_MBUF_COUNT];
 
-    cne_printf("[blue]>>>[white]SUBTEST:  test_pktmbuf_pool\n");
+    tst_info("SUBTEST:  test_pktmbuf_pool");
 
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_copy\n");
+    tst_info("SUBTEST: pktmbuf_copy");
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
     pktmbuf_t *extra = NULL;
     extra            = pktmbuf_copy(m[0], pi, 0, UINT32_MAX);
     TST_ASSERT_GOTO(extra != NULL, "SUBTEST: pktmbuf_copy\n", leave);
-    tst_ok("PASS ---  SUBTEST: pktmbuf_copy\n");
+    tst_ok("PASS ---  SUBTEST: pktmbuf_copy");
 
     /* free them */
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++) {
@@ -320,12 +296,12 @@ test_pktmbuf_pool(void)
     }
 
     pktmbuf_free(extra);
-    tst_ok("PASS --- SUBTEST:  test_pktmbuf_pool\n");
+    tst_ok("PASS --- SUBTEST:  test_pktmbuf_pool");
 
     return 0;
 
 leave:
-    tst_error("FAILED --- SUBTEST:  test_pktmbuf_pool\n");
+    tst_error("FAILED --- SUBTEST:  test_pktmbuf_pool");
     return -1;
 }
 
@@ -343,14 +319,13 @@ test_pktmbuf_pool_ptr(void)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < NB_MBUF; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
         m[i]->data_off += 64;
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
     /* free them */
     for (i = 0; i < NB_MBUF; i++) {
         pktmbuf_free(m[i]);
@@ -360,15 +335,14 @@ test_pktmbuf_pool_ptr(void)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < NB_MBUF; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
         TST_ASSERT_GOTO(m[i]->data_off == CNE_PKTMBUF_HEADROOM, "SUBTEST: alloc NB_MBUF mbufs\n",
                         leave);
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
 
 leave:
     /* free them */
@@ -376,6 +350,7 @@ leave:
         pktmbuf_free(m[i]);
     }
 
+    tst_info("NB_MBUF subtest resulted in leave call");
     return ret;
 }
 
@@ -386,7 +361,7 @@ verify_mbuf_check_panics(pktmbuf_t *buf)
     int pid;
     int status;
 
-    cne_printf("[green]");
+    vt_color(VT_GREEN, VT_NO_CHANGE, VT_OFF);
     pid = fork();
 
     if (pid == 0) {
@@ -415,77 +390,67 @@ test_failing_pktmbuf_sanity_check(void)
     pktmbuf_t *buf;
     pktmbuf_t badbuf;
 
-    cne_printf("[blue]>>>[white]SUBTEST: Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_info("SUBTEST: Checking pktmbuf_sanity_check for failure conditions");
 
     /* get a good pktmbuf to use to make copies */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     buf = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(buf, "SUBTEST: pktmbuf_alloc failed\n", leave);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
 
-    cne_printf("[magenta]Checking good pktmbuf initially\n");
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("Checking good pktmbuf initially");
+    tst_info("SUBTEST: verify_mbuf_check_panics");
     TST_ASSERT_GOTO(verify_mbuf_check_panics(buf) == -1,
                     "SUBTEST: verify_mbuf_check_panics failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics");
 
-    cne_printf("[magenta]Now checking for error conditions - [green]Note PANICS are GOOD HERE\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("Now checking for error conditions - Note PANICS are GOOD HERE");
+    tst_info("SUBTEST: verify_mbuf_check_panics on NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(NULL),
                     "SUBTEST: verify_mbuf_check_panics on NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on NULL");
 
     badbuf          = *buf;
     badbuf.pooldata = NULL;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.pool = NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.pool = NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL");
 
     badbuf          = *buf;
     badbuf.buf_addr = 0;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0 failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0");
 
     badbuf          = *buf;
     badbuf.buf_addr = NULL;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL");
 
     badbuf        = *buf;
     badbuf.refcnt = 0;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0 failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0");
 
     badbuf        = *buf;
     badbuf.refcnt = UINT16_MAX;
-    cne_printf(
-        "\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX failed\n",
                     leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX");
 
-    tst_ok("PASS --- SUBTEST:  Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_ok("PASS --- SUBTEST:  Checking pktmbuf_sanity_check for failure conditions");
     return 0;
 
 leave:
-    tst_error("FAILED --- SUBTEST: Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_error("FAILED --- SUBTEST: Checking pktmbuf_sanity_check for failure conditions");
     return -1;
 }
 
@@ -498,28 +463,26 @@ test_pktmbuf_with_non_ascii_data(void)
     pktmbuf_t *m = NULL;
     char *data;
 
-    cne_printf("[blue]>>>[white]SUBTEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_info("SUBTEST: test_pktmbuf_with_non_ascii_data");
 
     /* alloc a pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     m = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(m, "SUBTEST: pktmbuf_alloc failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == 0, "SUBTEST: pktmbuf_alloc failed\n", fail);
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append");
     data = pktmbuf_append(m, MBUF_TEST_DATA_LEN);
     TST_ASSERT_GOTO(data != NULL, "SUBTEST: pktmbuf_append failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: pktmbuf_alloc failed\n",
                     fail);
 
     memset(data, 0xff, pktmbuf_data_len(m));
     tst_ok("PASS --- SUBTEST:  test_pktmbuf_with_non_ascii_data\n");
 
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, MBUF_TEST_DATA_LEN);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
@@ -528,7 +491,7 @@ test_pktmbuf_with_non_ascii_data(void)
     return 0;
 
 fail:
-    tst_error("FAILED --- SUBTEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_error("FAILED --- SUBTEST: test_pktmbuf_with_non_ascii_data");
     pktmbuf_free(m);
     return -1;
 }
@@ -538,47 +501,42 @@ test_mbuf(void)
 {
     /* create pktmbuf pool if it does not exist */
     if (pi == NULL) {
-        cne_printf("\n[blue]>>>[white]TEST: pktmbuf_pool_create\n");
-        vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+        tst_info("TEST: pktmbuf_pool_create");
         if (create_pktmbuf())
             goto leave;
-        tst_ok("PASS --- TEST: pktmbuf_pool_create\n");
+        tst_ok("PASS --- TEST: pktmbuf_pool_create");
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: test multiple pktmbuf alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test multiple pktmbuf alloc");
     TST_ASSERT_GOTO(!test_pktmbuf_pool(), "TEST: test multiple pktmbuf alloc failed\n", leave);
-    tst_ok("PASS --- TEST: test multiple pktmbuf alloc\n");
+    tst_ok("PASS --- TEST: test multiple pktmbuf alloc");
 
     /* test that the pointer to the data on a packet pktmbuf is set properly */
-    cne_printf("\n[blue]>>>[white]TEST: test_pktmbuf_pool_ptr\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_pktmbuf_pool_ptr");
     TST_ASSERT_GOTO(!test_pktmbuf_pool_ptr(), "TEST: test_pktmbuf_pool_ptr failed\n", leave);
-    tst_ok("PASS --- TEST: test_pktmbuf_pool_ptr\n");
+    tst_ok("PASS --- TEST: test_pktmbuf_pool_ptr");
 
     /* test data manipulation in pktmbuf */
-    cne_printf("\n[blue]>>>[white]TEST: test_one_pktmbuf\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_one_pktmbuf");
     TST_ASSERT_GOTO(!test_one_pktmbuf(), "TEST: test_one_pktmbuf failed\n", leave);
-    tst_ok("PASS --- TEST: test_one_pktmbuf\n");
+    tst_ok("PASS --- TEST: test_one_pktmbuf");
 
-    cne_printf("\n[blue]>>>[white]TEST: test_pktmbuf_with_non_ascii_data\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_pktmbuf_with_non_ascii_data");
     TST_ASSERT_GOTO(!test_pktmbuf_with_non_ascii_data(),
                     "TEST: test_pktmbuf_with_non_ascii_data failed\n", leave);
-    tst_ok("PASS --- TEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_ok("PASS --- TEST: test_pktmbuf_with_non_ascii_data");
 
-    cne_printf("\n[blue]>>>[white]TEST: test_failing_pktmbuf_sanity_check\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_failing_pktmbuf_sanity_check");
     TST_ASSERT_GOTO(!test_failing_pktmbuf_sanity_check(),
                     "TEST: test_failing_pktmbuf_sanity_check failed\n", leave);
-    tst_ok("PASS --- TEST: test_failing_pktmbuf_sanity_check\n");
+    tst_ok("PASS --- TEST: test_failing_pktmbuf_sanity_check");
 
     return 0;
 
 leave:
 
     destroy_pktmbuf();
+    tst_error("mbuf tests failed");
     return -1;
 }
 


### PR DESCRIPTION
Creating updated pull request for pkt_test.c. This included removing cne_printf() calls, wrapping vt_color() calls, and removing unnecessary '/n' characters to tst_XXX() calls [these naturally insert a '/n' for you].