### PR TITLE
Bugfix/meson build issue

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -431,11 +431,13 @@ cndp_so_name = 'libcndp.so'
 
 mklib = find_program('tools/mklib.sh')
 
+tempdir = run_command('mktemp', check: true)
+
 if use_static_libs
     run_command(mklib, cndp_a_name, libcndp_a, check: true)
     cndp_a = custom_target('libcndp_a_target',
         output: cndp_a_name,
-        input: join_paths('/tmp', cndp_a_name),
+        input: join_paths(tempdir, cndp_a_name),
         command:[find_program('cp'), '@INPUT@', cndp_a_name],
         install_dir: join_paths('lib', 'x86_64-linux-gnu'),
         install: true)
@@ -443,7 +445,7 @@ else
     run_command(mklib, cndp_so_name, libcndp_so, check: true)
     cndp_so = custom_target('libcndp_so_target',
         output: cndp_so_name,
-        input: join_paths('/tmp', cndp_so_name),
+        input: join_paths(tempdir, cndp_so_name),
         command:[find_program('cp'), '@INPUT@', cndp_so_name],
         install_dir: join_paths('lib', 'x86_64-linux-gnu'),
         install: true)
@@ -459,7 +461,7 @@ cndp_pmds_a_name = 'libcndp_pmds.a'
 run_command(mklib, cndp_pmds_a_name, libcndp_pmds_a, check: true)
 cndp_pmds_a = custom_target('libcndp_pmds_a_target',
     output: cndp_pmds_a_name,
-    input: join_paths('/tmp', cndp_pmds_a_name),
+    input: join_paths(tempdir, cndp_pmds_a_name),
     command:[find_program('cp'), '@INPUT@', cndp_pmds_a_name],
     install_dir: join_paths('lib', 'x86_64-linux-gnu'),
     install: true)

--- a/meson.build
+++ b/meson.build
@@ -431,10 +431,10 @@ cndp_so_name = 'libcndp.so'
 
 mklib = find_program('tools/mklib.sh')
 
-tempdir = run_command('mktemp', check: true)
+tempdir = run_command('mktemp', check: true).stdout().strip()
 
 if use_static_libs
-    run_command(mklib, cndp_a_name, libcndp_a, check: true)
+    run_command(mklib, join_paths(tempdir, cndp_a_name), libcndp_a, check: true)
     cndp_a = custom_target('libcndp_a_target',
         output: cndp_a_name,
         input: join_paths(tempdir, cndp_a_name),
@@ -442,7 +442,7 @@ if use_static_libs
         install_dir: join_paths('lib', 'x86_64-linux-gnu'),
         install: true)
 else
-    run_command(mklib, cndp_so_name, libcndp_so, check: true)
+    run_command(mklib, join_paths(tempdir, cndp_so_name), libcndp_so, check: true)
     cndp_so = custom_target('libcndp_so_target',
         output: cndp_so_name,
         input: join_paths(tempdir, cndp_so_name),

--- a/meson.build
+++ b/meson.build
@@ -430,11 +430,10 @@ cndp_a_name = 'libcndp.a'
 cndp_so_name = 'libcndp.so'
 
 mklib = find_program('tools/mklib.sh')
-
-tempdir = run_command('mktemp', check: true).stdout().strip()
+tempdir = run_command('mktemp', '-d', check: true).stdout().strip()
 
 if use_static_libs
-    run_command(mklib, join_paths(tempdir, cndp_a_name), libcndp_a, check: true)
+    run_command(mklib, tempdir, cndp_a_name, libcndp_a, check: true)
     cndp_a = custom_target('libcndp_a_target',
         output: cndp_a_name,
         input: join_paths(tempdir, cndp_a_name),
@@ -442,7 +441,7 @@ if use_static_libs
         install_dir: join_paths('lib', 'x86_64-linux-gnu'),
         install: true)
 else
-    run_command(mklib, join_paths(tempdir, cndp_so_name), libcndp_so, check: true)
+    run_command(mklib, tempdir, cndp_so_name, libcndp_so, check: true)
     cndp_so = custom_target('libcndp_so_target',
         output: cndp_so_name,
         input: join_paths(tempdir, cndp_so_name),
@@ -458,7 +457,7 @@ foreach lib:enabled_pmd_libs
 endforeach
 
 cndp_pmds_a_name = 'libcndp_pmds.a'
-run_command(mklib, cndp_pmds_a_name, libcndp_pmds_a, check: true)
+run_command(mklib, tempdir, cndp_pmds_a_name, libcndp_pmds_a, check: true)
 cndp_pmds_a = custom_target('libcndp_pmds_a_target',
     output: cndp_pmds_a_name,
     input: join_paths(tempdir, cndp_pmds_a_name),

--- a/tools/mklib.sh
+++ b/tools/mklib.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-outfile=$1
-shift 1
+outdir=$1
+outfile=$2
+shift 2
 
-echo "GROUP (" $* ")" > $outfile
+echo "GROUP (" $* ")" > "$outdir/$outfile"

--- a/tools/mklib.sh
+++ b/tools/mklib.sh
@@ -4,4 +4,4 @@ outdir=$1
 outfile=$2
 shift 2
 
-echo "GROUP (" $* ")" > "$outdir/$outfile"
+echo "GROUP (" "$*" ")" > "$outdir/$outfile"

--- a/tools/mklib.sh
+++ b/tools/mklib.sh
@@ -3,4 +3,4 @@
 outfile=$1
 shift 1
 
-echo "GROUP (" $* ")" > /tmp/$outfile
+echo "GROUP (" $* ")" > $outfile


### PR DESCRIPTION
Meson build will not let multiple people working on a box to build. It leads to conflict as it is stored to the `/tmp/` directory. This leads to issues if you have multiple people with same box/level access on a machine. This build change fixes that so instead it uses `/tmp/tmp.<random_UID>/` to store the libcndp.so file and libcndp_pmds.a file.